### PR TITLE
Update to v12

### DIFF
--- a/Classes/AdditionalContentFields.php
+++ b/Classes/AdditionalContentFields.php
@@ -71,7 +71,7 @@ class AdditionalContentFields
         if ($this->maskColumns) {
             $columns = explode(',', $this->maskColumns);
             foreach ($columns as $column) {
-                if (!is_numeric($ttContentRow[$column])) {
+                if (!is_numeric($ttContentRow[$column]) && $ttContentRow[$column]) {
                     // add the content to bodytext
                     $bodytext .= strip_tags($ttContentRow[$column]);
                 } elseif ($ttContentRow[$column] && is_array($ttContentRow)) {
@@ -125,23 +125,23 @@ class AdditionalContentFields
     {
         $link = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable($table);
-        
+
         $increaseGroupConcatSql= 'SET SESSION group_concat_max_len = 1000000';
         $statement = $link->prepare($increaseGroupConcatSql);
         $statement->execute();
 
         $sql = "SELECT GROUP_CONCAT(COLUMN_NAME) as columns
-    FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE table_name = '" . $table . "'
-    AND table_schema = '" . $link->getDatabase() . "'
-    AND column_name LIKE 'tx_mask_%'
-    GROUP BY table_name
-    ";
+                FROM INFORMATION_SCHEMA.COLUMNS
+                WHERE table_name = '" . $table . "'
+                AND table_schema = '" . $link->getDatabase() . "'
+                AND column_name LIKE 'tx_mask_%'
+                GROUP BY table_name
+                ";
 
         $statement = $link->prepare($sql);
-        $statement->execute();
+        $result = $statement->execute();
 
-        while ($row = $statement->fetch(FetchMode::ASSOCIATIVE)) {
+        while ($row = $result->fetchAssociative()) {
             return $row['columns'];
         }
     }

--- a/Classes/AdditionalContentFields.php
+++ b/Classes/AdditionalContentFields.php
@@ -20,6 +20,7 @@
 
 namespace Zwo3\MaskKesearchIndexer;
 
+use Tpwd\KeSearch\Indexer\Types\Page;
 use Doctrine\DBAL\FetchMode;
 use Tpwd\KeSearch\Lib\Db;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -50,7 +51,7 @@ class AdditionalContentFields
 
     /**
      * @param string $fields
-     * @param \Tpwd\KeSearch\Indexer\Types\Page $pageIndexer
+     * @param Page $pageIndexer
      */
     public function modifyPageContentFields(&$fields, $pageIndexer)
     {
@@ -63,7 +64,7 @@ class AdditionalContentFields
     /**
      * @param string $bodytext
      * @param array $ttContentRow
-     * @param \Tpwd\KeSearch\Indexer\Types\Page $pageIndexer
+     * @param Page $pageIndexer
      */
     public function modifyContentFromContentElement(string &$bodytext, array $ttContentRow, $pageIndexer)
     {
@@ -94,18 +95,13 @@ class AdditionalContentFields
     {$queryBuilder = Db::getQueryBuilder($table);
         $pageQuery = $queryBuilder
             ->select(...$columns)
-            ->from($table)
-            ->where(
-                $queryBuilder->expr()
-                    ->eq(
-                        'pid', $queryBuilder->createNamedParameter($pid)
-                    ),
-                $queryBuilder->expr()
-                    ->eq(
-                        'sys_language_uid', $queryBuilder->createNamedParameter($sys_language_uid)
-                    )
-            )
-            ->execute();
+            ->from($table)->where($queryBuilder->expr()
+            ->eq(
+                'pid', $queryBuilder->createNamedParameter($pid)
+            ), $queryBuilder->expr()
+            ->eq(
+                'sys_language_uid', $queryBuilder->createNamedParameter($sys_language_uid)
+            ))->executeQuery();
 
         $bodytext = '';
         while ($row = $pageQuery->fetch()) {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "license": ["GPL-2.0-or-later"],
   "require": {
-    "typo3/cms-core": "^11.5.0",
+    "typo3/cms-core": "^11.5.0 || ^12.4.0",
     "tpwd/ke_search": "^v4.2.0",
     "mask/mask": "^v7.0.21"
   },

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
   "license": ["GPL-2.0-or-later"],
   "require": {
     "typo3/cms-core": "^11.5.0 || ^12.4.0",
-    "tpwd/ke_search": "^v4.2.0",
-    "mask/mask": "^v7.0.21"
+    "tpwd/ke_search": "^4.2.0 || ^5.0",
+    "mask/mask": "^7.0.21 || ^8.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,13 @@
     "mask",
     "indexer"
   ],
-  "license": ["GPL-2.0-or-later"],
+  "license": [
+    "GPL-2.0-or-later"
+  ],
   "require": {
-    "typo3/cms-core": "^11.5.0 || ^12.4.0",
-    "tpwd/ke_search": "^4.2.0 || ^5.0",
-    "mask/mask": "^7.0.21 || ^8.2"
+    "typo3/cms-core": "^12.4.0",
+    "tpwd/ke_search": "^5.0",
+    "mask/mask": "^8.2"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,9 +10,9 @@ $EM_CONF['mask_kesearch_indexer'] = array(
     'author_company' => 'zwo3',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '11.5.0-12.4.99',
-            'mask' => '7.0.21-8.9.99',
-            'ke_search' => '4.2.0-5.9.99',
+            'typo3' => '12.3.0-12.4.99',
+            'mask' => '8.0.0-8.9.99',
+            'ke_search' => '5.0.0-5.9.99',
         ),
         'conflicts' => array(),
         'suggests' => array(),

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,9 +12,9 @@ $EM_CONF['mask_kesearch_indexer'] = array(
     'author_company' => 'zwo3',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '11.5.0-11.5.99',
-            'mask' => '7.0.21-7.0.99',
-            'ke_search' => '4.2.0-4.9.99',
+            'typo3' => '11.5.0-12.4.99',
+            'mask' => '7.0.21-8.9.99',
+            'ke_search' => '4.2.0-5.9.99',
         ),
         'conflicts' => array(),
         'suggests' => array(),

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,11 +1,9 @@
-
 <?php
 $EM_CONF['mask_kesearch_indexer'] = array(
     'title' => 'KeSearch Indexer for Mask Elements',
     'description' => 'Indexer for mask elements, both tt_content columns and tx_mask-tables.',
     'category' => 'backend',
     'version' => '2.2.1',
-    'dependencies' => 'ke_search, mask',
     'state' => 'stable',
     'author' => 'Gregor Agnes',
     'author_email' => 'ga@zwo3.de',

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -16,11 +16,11 @@
  *  GNU General Public License for more details.
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-if (!defined("TYPO3_MODE")) {
+if (!defined('TYPO3')) {
     die("Access denied.");
 }
 
 // Register hooks for indexing additional fields.
-$additionContentClassName = 'Zwo3\MaskKesearchIndexer\AdditionalContentFields';
+$additionContentClassName = \Zwo3\MaskKesearchIndexer\AdditionalContentFields::class;
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyPageContentFields'][] = $additionContentClassName;
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ke_search']['modifyContentFromContentElement'][] = $additionContentClassName;


### PR DESCRIPTION
Hello,

we needed your extension for our recent typo3 v12 Update and so I upgraded it.

What I did:

1. set Versions for TYPO3 12 so I can install the extension
2. rectored the files for PHP 8.1 and TYPO3 12 changes
3. Doctrine\DBAL\Statement and Doctrine\DBAL\Result changed, so I fixed [Classes/AdditionalContentFields.php] so the indexer runs again.
4. Tested it on v12 => works perfectly for our project that has only mask contentelements
5. Testet it on v11 => because of Doctrine\DBAL changes I haven't made it backwards compatible. I could with some conditions if the value of statement->execute() is a bool or a Doctrinte\DBAL\Result class, but I didn't want to bloat the function. 

